### PR TITLE
Quick Learning Notebook: Loading .env files with Python-Dotenv

### DIFF
--- a/programming-tricks/Loading Env Files with DotEnv.ipynb
+++ b/programming-tricks/Loading Env Files with DotEnv.ipynb
@@ -1,0 +1,216 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Loading .env Files into Environment Variabiles with Python-DotEnv\n",
+    "\n",
+    "Documentation: https://pypi.org/project/python-dotenv/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting python-dotenv\n",
+      "  Downloading python_dotenv-1.0.0-py3-none-any.whl (19 kB)\n",
+      "Installing collected packages: python-dotenv\n",
+      "Successfully installed python-dotenv-1.0.0\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install python-dotenv "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The Problem: .env files are great, but IDE Tooling is Fickle\n",
+    "\n",
+    "We use .env files to specify which environment variables should be present for a project, but so far actually using them (particularly from the terminal, where we've been copy-pasting `export {KEY}={VALUE}` over and over again) has gotten annoying.\n",
+    "\n",
+    "It would be great if the .env files were actually integrated into the code, without sacrificing the security aspects of it and losing out on the IDE features when they are used.  Reading a bit, it looks like `python-dotenv` might be the magic there.\n",
+    "\n",
+    "\n",
+    "### Goal: Use Python-DotEnv to load variables in a .env file into the environment that the Python script is using."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Step 1: Create a .env file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "23"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "env_text = \"\"\"\n",
+    "VAR1=hello\n",
+    "VAR2=world\n",
+    "\"\"\"\n",
+    "Path('.env').write_text(env_text)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Step 2: Check that the VAR1 and VAR2 environment variables don't exist."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ.get('VAR1')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ.get('VAR2')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Step 3: Load the .env file with `dotenv.load_dotenv()`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from dotenv import load_dotenv\n",
+    "load_dotenv()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Step 3: Check that the VAR1 and VAR2 environment variables now do exist!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'hello'"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "os.environ.get('VAR1')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'world'"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "os.environ.get('VAR2')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Okay, that was easy.  Great tool!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "httpx",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Hi,

Here's a notebook I made to check out Python Dotenv (https://pypi.org/project/python-dotenv/) for loading .env files into environment variables.  Just calling `dotenv.load_dotenv()` does the trick, I thought it works great!  I thought it might be a good solution for simplifying our work on the `workshop-registration` project; in any case, a nice tool to have in the toolbelt.

Best wishes,

Nick